### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/01-autogen-demo.ipynb
+++ b/01-autogen-demo.ipynb
@@ -10,15 +10,15 @@
      "output_type": "stream",
      "text": [
       "\u001b[33mWARNING: Skipping autogen as it is not installed.\u001b[0m\u001b[33m\n",
-      "\u001b[0mFound existing installation: pyautogen 0.2.1\n",
-      "Uninstalling pyautogen-0.2.1:\n",
-      "  Successfully uninstalled pyautogen-0.2.1\n",
+      "\u001b[0mFound existing installation: ag2 0.2.1\n",
+      "Uninstalling ag2-0.2.1:\n",
+      "  Successfully uninstalled ag2-0.2.1\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
    ],
    "source": [
-    "%pip uninstall autogen pyautogen -y"
+    "%pip uninstall autogen ag2 -y"
    ]
   },
   {
@@ -30,41 +30,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Collecting pyautogen\n",
-      "  Downloading pyautogen-0.2.2-py3-none-any.whl (124 kB)\n",
+      "Collecting ag2\n",
+      "  Downloading ag2-0.2.2-py3-none-any.whl (124 kB)\n",
       "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m124.0/124.0 kB\u001b[0m \u001b[31m6.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25hRequirement already satisfied: diskcache in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from pyautogen) (5.6.3)\n",
-      "Requirement already satisfied: flaml in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from pyautogen) (2.1.1)\n",
+      "\u001b[?25hRequirement already satisfied: diskcache in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from ag2) (5.6.3)\n",
+      "Requirement already satisfied: flaml in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from ag2) (2.1.1)\n",
       "Collecting openai~=1.3\n",
       "  Downloading openai-1.3.8-py3-none-any.whl (221 kB)\n",
       "\u001b[2K     \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m221.5/221.5 kB\u001b[0m \u001b[31m15.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25hRequirement already satisfied: python-dotenv in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from pyautogen) (1.0.0)\n",
-      "Requirement already satisfied: termcolor in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from pyautogen) (2.4.0)\n",
-      "Requirement already satisfied: tiktoken in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from pyautogen) (0.5.2)\n",
-      "Requirement already satisfied: anyio<5,>=3.5.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->pyautogen) (3.7.1)\n",
-      "Requirement already satisfied: distro<2,>=1.7.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->pyautogen) (1.8.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->pyautogen) (0.25.2)\n",
-      "Requirement already satisfied: pydantic<3,>=1.9.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->pyautogen) (2.5.2)\n",
-      "Requirement already satisfied: sniffio in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->pyautogen) (1.3.0)\n",
-      "Requirement already satisfied: tqdm>4 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->pyautogen) (4.66.1)\n",
-      "Requirement already satisfied: typing-extensions<5,>=4.5 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->pyautogen) (4.9.0)\n",
-      "Requirement already satisfied: NumPy>=1.17.0rc1 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from flaml->pyautogen) (1.26.2)\n",
-      "Requirement already satisfied: regex>=2022.1.18 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from tiktoken->pyautogen) (2023.10.3)\n",
-      "Requirement already satisfied: requests>=2.26.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from tiktoken->pyautogen) (2.31.0)\n",
-      "Requirement already satisfied: idna>=2.8 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from anyio<5,>=3.5.0->openai~=1.3->pyautogen) (3.6)\n",
-      "Requirement already satisfied: certifi in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from httpx<1,>=0.23.0->openai~=1.3->pyautogen) (2023.11.17)\n",
-      "Requirement already satisfied: httpcore==1.* in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from httpx<1,>=0.23.0->openai~=1.3->pyautogen) (1.0.2)\n",
-      "Requirement already satisfied: h11<0.15,>=0.13 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai~=1.3->pyautogen) (0.14.0)\n",
-      "Requirement already satisfied: annotated-types>=0.4.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai~=1.3->pyautogen) (0.6.0)\n",
-      "Requirement already satisfied: pydantic-core==2.14.5 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai~=1.3->pyautogen) (2.14.5)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from requests>=2.26.0->tiktoken->pyautogen) (3.3.2)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from requests>=2.26.0->tiktoken->pyautogen) (2.1.0)\n",
-      "Installing collected packages: openai, pyautogen\n",
+      "\u001b[?25hRequirement already satisfied: python-dotenv in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from ag2) (1.0.0)\n",
+      "Requirement already satisfied: termcolor in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from ag2) (2.4.0)\n",
+      "Requirement already satisfied: tiktoken in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from ag2) (0.5.2)\n",
+      "Requirement already satisfied: anyio<5,>=3.5.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->ag2) (3.7.1)\n",
+      "Requirement already satisfied: distro<2,>=1.7.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->ag2) (1.8.0)\n",
+      "Requirement already satisfied: httpx<1,>=0.23.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->ag2) (0.25.2)\n",
+      "Requirement already satisfied: pydantic<3,>=1.9.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->ag2) (2.5.2)\n",
+      "Requirement already satisfied: sniffio in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->ag2) (1.3.0)\n",
+      "Requirement already satisfied: tqdm>4 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->ag2) (4.66.1)\n",
+      "Requirement already satisfied: typing-extensions<5,>=4.5 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from openai~=1.3->ag2) (4.9.0)\n",
+      "Requirement already satisfied: NumPy>=1.17.0rc1 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from flaml->ag2) (1.26.2)\n",
+      "Requirement already satisfied: regex>=2022.1.18 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from tiktoken->ag2) (2023.10.3)\n",
+      "Requirement already satisfied: requests>=2.26.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from tiktoken->ag2) (2.31.0)\n",
+      "Requirement already satisfied: idna>=2.8 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from anyio<5,>=3.5.0->openai~=1.3->ag2) (3.6)\n",
+      "Requirement already satisfied: certifi in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from httpx<1,>=0.23.0->openai~=1.3->ag2) (2023.11.17)\n",
+      "Requirement already satisfied: httpcore==1.* in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from httpx<1,>=0.23.0->openai~=1.3->ag2) (1.0.2)\n",
+      "Requirement already satisfied: h11<0.15,>=0.13 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai~=1.3->ag2) (0.14.0)\n",
+      "Requirement already satisfied: annotated-types>=0.4.0 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai~=1.3->ag2) (0.6.0)\n",
+      "Requirement already satisfied: pydantic-core==2.14.5 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai~=1.3->ag2) (2.14.5)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from requests>=2.26.0->tiktoken->ag2) (3.3.2)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/bx66-286/.pyenv/versions/3.11.2/lib/python3.11/site-packages (from requests>=2.26.0->tiktoken->ag2) (2.1.0)\n",
+      "Installing collected packages: openai, ag2\n",
       "  Attempting uninstall: openai\n",
       "    Found existing installation: openai 1.2.4\n",
       "    Uninstalling openai-1.2.4:\n",
       "      Successfully uninstalled openai-1.2.4\n",
-      "Successfully installed openai-1.3.8 pyautogen-0.2.2\n",
+      "Successfully installed openai-1.3.8 ag2-0.2.2\n",
       "\n",
       "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip available: \u001b[0m\u001b[31;49m22.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.1\u001b[0m\n",
       "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
@@ -73,7 +73,7 @@
     }
    ],
    "source": [
-    "%pip install pyautogen"
+    "%pip install ag2"
    ]
   },
   {
@@ -85,13 +85,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "pyautogen==0.2.2\n",
+      "ag2==0.2.2\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
    ],
    "source": [
-    "%pip freeze | grep pyautogen"
+    "%pip freeze | grep ag2"
    ]
   },
   {


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
